### PR TITLE
Add route for admin to create user client API keys

### DIFF
--- a/app/Http/Controllers/Api/Application/Users/UserApiKeyController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserApiKeyController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Pterodactyl\Http\Controllers\Api\Application\Users;
+
+use Pterodactyl\Models\User;
+use Pterodactyl\Models\ApiKey;
+use Pterodactyl\Facades\Activity;
+use Pterodactyl\Exceptions\DisplayException;
+use Pterodactyl\Transformers\Api\Application\ApiKeyTransformer;
+use Pterodactyl\Http\Controllers\Api\Application\ApplicationApiController;
+use Pterodactyl\Http\Requests\Api\Application\Users\StoreUserApiKeyRequest;
+
+class UserApiKeyController extends ApplicationApiController
+{
+    public function store(StoreUserApiKeyRequest $request, User $user): array
+    {
+        if ($user->apiKeys()->where('key_type', ApiKey::TYPE_ACCOUNT)->count() >= 25) {
+            throw new DisplayException('You have reached the account limit for number of API keys.');
+        }
+
+        $token = $user->createToken(
+            $request->input('description'),
+            $request->input('allowed_ips')
+        );
+
+        Activity::event('user:api-key.create')
+            ->subject($token->accessToken)
+            ->property('identifier', $token->accessToken->identifier)
+            ->log();
+
+        return $this->fractal->item($token->accessToken)
+            ->transformWith($this->getTransformer(ApiKeyTransformer::class))
+            ->addMeta(['secret_token' => $token->plainTextToken])
+            ->toArray();
+    }
+}

--- a/app/Http/Requests/Api/Application/Users/StoreUserApiKeyRequest.php
+++ b/app/Http/Requests/Api/Application/Users/StoreUserApiKeyRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Pterodactyl\Http\Requests\Api\Application\Users;
+
+use IPTools\Range;
+use Illuminate\Validation\Validator;
+use Pterodactyl\Models\ApiKey;
+use Pterodactyl\Services\Acl\Api\AdminAcl;
+use Pterodactyl\Http\Requests\Api\Application\ApplicationApiRequest;
+
+class StoreUserApiKeyRequest extends ApplicationApiRequest
+{
+    protected ?string $resource = AdminAcl::RESOURCE_USERS;
+
+    protected int $permission = AdminAcl::WRITE;
+
+    public function rules(): array
+    {
+        $rules = ApiKey::getRules();
+
+        return [
+            'description' => $rules['memo'],
+            'allowed_ips' => [...$rules['allowed_ips'], 'max:50'],
+            'allowed_ips.*' => 'string',
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            if (!is_array($ips = $this->input('allowed_ips'))) {
+                return;
+            }
+
+            foreach ($ips as $index => $ip) {
+                $valid = false;
+                try {
+                    $valid = Range::parse($ip)->valid();
+                } catch (\Exception $exception) {
+                    if ($exception->getMessage() !== 'Invalid IP address format') {
+                        throw $exception;
+                    }
+                } finally {
+                    $validator->errors()->addIf(!$valid, "allowed_ips.{$index}", '"' . $ip . '" is not a valid IP address or CIDR range.');
+                }
+            }
+        });
+    }
+}

--- a/app/Transformers/Api/Application/ApiKeyTransformer.php
+++ b/app/Transformers/Api/Application/ApiKeyTransformer.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Pterodactyl\Transformers\Api\Application;
+
+use Pterodactyl\Models\ApiKey;
+
+class ApiKeyTransformer extends BaseTransformer
+{
+    public function getResourceName(): string
+    {
+        return ApiKey::RESOURCE_NAME;
+    }
+
+    public function transform(ApiKey $model): array
+    {
+        return [
+            'identifier' => $model->identifier,
+            'description' => $model->memo,
+            'allowed_ips' => $model->allowed_ips,
+            'last_used_at' => $model->last_used_at ? $model->last_used_at->toAtomString() : null,
+            'created_at' => $model->created_at->toAtomString(),
+        ];
+    }
+}

--- a/routes/api-application.php
+++ b/routes/api-application.php
@@ -18,6 +18,7 @@ Route::group(['prefix' => '/users'], function () {
     Route::get('/external/{external_id}', [Application\Users\ExternalUserController::class, 'index'])->name('api.application.users.external');
 
     Route::post('/', [Application\Users\UserController::class, 'store']);
+    Route::post('/{user:id}/api-keys', [Application\Users\UserApiKeyController::class, 'store']);
     Route::patch('/{user:id}', [Application\Users\UserController::class, 'update']);
 
     Route::delete('/{user:id}', [Application\Users\UserController::class, 'delete']);

--- a/tests/Integration/Api/Application/Users/UserApiKeyControllerTest.php
+++ b/tests/Integration/Api/Application/Users/UserApiKeyControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Pterodactyl\Tests\Integration\Api\Application\Users;
+
+use Pterodactyl\Models\User;
+use Illuminate\Http\Response;
+use Pterodactyl\Models\ApiKey;
+use Pterodactyl\Services\Acl\Api\AdminAcl;
+use Pterodactyl\Transformers\Api\Application\ApiKeyTransformer;
+use Pterodactyl\Tests\Integration\Api\Application\ApplicationApiIntegrationTestCase;
+
+class UserApiKeyControllerTest extends ApplicationApiIntegrationTestCase
+{
+    protected function tearDown(): void
+    {
+        ApiKey::query()->forceDelete();
+
+        parent::tearDown();
+    }
+
+    public function testApiKeyCanBeCreatedForUser()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/application/users/' . $user->id . '/api-keys', [
+            'description' => 'Test Key',
+            'allowed_ips' => ['127.0.0.1'],
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK)
+            ->assertJsonPath('object', ApiKey::RESOURCE_NAME);
+
+        $key = ApiKey::query()->where('identifier', $response->json('attributes.identifier'))->firstOrFail();
+
+        $response->assertJson([
+            'object' => ApiKey::RESOURCE_NAME,
+            'attributes' => $this->getTransformer(ApiKeyTransformer::class)->transform($key),
+            'meta' => ['secret_token' => decrypt($key->token)],
+        ], true);
+    }
+
+    public function testApiKeyLimitIsApplied()
+    {
+        $user = User::factory()->create();
+        ApiKey::factory()->times(25)->for($user)->create([
+            'key_type' => ApiKey::TYPE_ACCOUNT,
+        ]);
+
+        $this->postJson('/api/application/users/' . $user->id . '/api-keys', [
+            'description' => 'Test Key',
+        ])
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.code', 'DisplayException');
+    }
+
+    public function testApiKeyWithoutPermissionIsDenied()
+    {
+        $user = User::factory()->create();
+        $this->createNewDefaultApiKey($this->getApiUser(), ['r_users' => AdminAcl::READ]);
+
+        $response = $this->postJson('/api/application/users/' . $user->id . '/api-keys', [
+            'description' => 'Test',
+        ]);
+
+        $this->assertAccessDeniedJson($response);
+    }
+}


### PR DESCRIPTION
## Summary
- allow generating client API keys for users via application API
- implement request validation for creating user API keys
- add transformer for ApiKey in application API
- add integration tests for user API key creation
